### PR TITLE
added babel-preset dependency

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,7 +13,9 @@ var paths = {
 gulp.task('babel', function () {
     return gulp.src(paths.es6)
         .pipe(sourcemaps.init())
-        .pipe(babel())
+        .pipe(babel({
+            presets: ['es2015']
+        }))
         .pipe(sourcemaps.write('.', { sourceRoot: paths.sourceRoot }))
         .pipe(gulp.dest(paths.es5));
 });

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
+    "babel-preset-es2015": "*",
     "gulp": "*",
     "gulp-babel": "*",
     "gulp-sourcemaps": "*",


### PR DESCRIPTION
Hi,
Your set-up did not work for me, gulp-babel now needs a preset to be installed from npm. I added it and now all seems well. Here it is in case anybody else has the same issue. 
